### PR TITLE
Minor bug fix: one-word character names

### DIFF
--- a/Graph.ipynb
+++ b/Graph.ipynb
@@ -455,9 +455,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 2
 }

--- a/Graph.ipynb
+++ b/Graph.ipynb
@@ -155,7 +155,7 @@
     "        char_name = \" \".join(tup)\n",
     "        n = len(tup)\n",
     "        if n == 1:\n",
-    "            indices = [i for i, x in enumerate(words) if x == tup]\n",
+    "            indices = [i for i, x in enumerate(words) if x == tup[0]]\n",
     "        elif n == 2:\n",
     "            indices = [i for i, x in enumerate(bigr) if x == tup]\n",
     "        elif n == 3:\n",
@@ -455,9 +455,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
When the character list contains some single-token names (e.g. "Bart"), the tuple of this name is `('Bart',)`. Although the length of this tuple is 1, I believe we should explicitly select `tup[0]` in this case (else the list of indices for single-token character names remains empty.

`if n == 1:`
    `indices = [i for i, x in enumerate(words) if x == tup[0]]`